### PR TITLE
Added support for sparse matrix input in UMAP function in scROSHI

### DIFF
--- a/R/scROSHI.R
+++ b/R/scROSHI.R
@@ -194,6 +194,12 @@ scROSHI <- function(sce_data,
   idx <- match(all.ct.genes, rownames(tmp))
   idx <- idx[!is.na(idx)]
   tmp <- tmp[idx, ]
+
+  # Fix sparse matrix
+  if (is(tmp, "sparseMatrix")) {
+    tmp <- Matrix::as.matrix(tmp)
+  }
+
   r.umap <- uwot::umap(t(tmp), n_neighbors = n_nn, spread = 1, min_dist = 0.01,
                  #y = sce_data$celltype.major,
                  ret_nn = T)


### PR DESCRIPTION
Title: Added Support for Sparse Matrix Input in UMAP function in scROSHI

Description:
This pull request aims to add support for sparse matrices when using the `uwot::umap` function. The original implementation did not handle sparse matrices from SingleCellExperiment.
This in response to the error:
```
Error in uwot(X = X, n_neighbors = n_neighbors, n_components = n_components,  : 
  Sparse matrices are only supported as distance matrices

```
Changes:
- Converted sparse matrix to dense matrix before passing it to `uwot::umap`.

Code:
```R
 # Fix sparse matrix
  if (is(tmp, "sparseMatrix")) {
    tmp <- Matrix::as.matrix(tmp)
  }